### PR TITLE
Add default argument for the postural task id

### DIFF
--- a/include/OpenSoT/tasks/acceleration/Postural.h
+++ b/include/OpenSoT/tasks/acceleration/Postural.h
@@ -37,10 +37,10 @@ namespace OpenSoT { namespace tasks { namespace acceleration {
         typedef boost::shared_ptr<Postural> Ptr;
         
         Postural(const XBot::ModelInterface& robot,
-                 AffineHelper qddot = AffineHelper(), std::string task_id = "Postural");
+                 AffineHelper qddot = AffineHelper(), const std::string task_id = "Postural");
 
         Postural(const XBot::ModelInterface& robot,
-                 const int x_size, std::string task_id = "Postural");
+                 const int x_size, const std::string task_id = "Postural");
         
         virtual void _update(const Eigen::VectorXd& x);
         

--- a/src/tasks/acceleration/Postural.cpp
+++ b/src/tasks/acceleration/Postural.cpp
@@ -1,7 +1,7 @@
 #include <OpenSoT/tasks/acceleration/Postural.h>
 
 OpenSoT::tasks::acceleration::Postural::Postural(
-         const XBot::ModelInterface& robot,const int x_size, std::string task_id):
+         const XBot::ModelInterface& robot,const int x_size, const std::string task_id):
     Task< Eigen::MatrixXd, Eigen::VectorXd >(task_id, x_size),
     _robot(robot)
 {
@@ -31,7 +31,7 @@ OpenSoT::tasks::acceleration::Postural::Postural(
 }
 
 OpenSoT::tasks::acceleration::Postural::Postural(const XBot::ModelInterface& robot,
-                                                 OpenSoT::AffineHelper qddot, std::string task_id):
+                                                 OpenSoT::AffineHelper qddot, const std::string task_id):
     Task< Eigen::MatrixXd, Eigen::VectorXd >(task_id, qddot.getInputSize()),
     _robot(robot),
     _qddot(qddot)


### PR DESCRIPTION
Add the possibility to add the task id for the postural tasks. It could be useful if you have multiple postural tasks. This PR should API compatible.