### PR TITLE
Deadzone setter updated

### DIFF
--- a/include/OpenSoT/tasks/velocity/CentauroAnkleSteering.h
+++ b/include/OpenSoT/tasks/velocity/CentauroAnkleSteering.h
@@ -31,11 +31,11 @@ namespace OpenSoT { namespace tasks { namespace velocity {
         
         double getCurrentThreshold() const;
         
-
+     private:
 
         double _th_lo, _th_hi;
         double _th_curr;
-        private:
+
     };
 
     
@@ -47,7 +47,7 @@ namespace OpenSoT { namespace tasks { namespace velocity {
         SimpleSteering(XBot::ModelInterface::ConstPtr model, 
                        std::string wheel_name,
                        std::vector<double> hyst_comp,
-                       std::vector<double> dz_th);
+                       double dz_th);
         
         double computeSteeringAngle(const Eigen::Vector3d& wheel_vel);
         
@@ -87,7 +87,7 @@ namespace OpenSoT { namespace tasks { namespace velocity {
         
         Eigen::Vector3d _vdes;
 
-        std::vector<double> _dz_th;
+        double _dz_th;
         
         double _prev_qdes;
         
@@ -104,9 +104,9 @@ namespace OpenSoT { namespace tasks { namespace velocity {
         CentauroAnkleSteering(std::string wheel_name, 
                               XBot::ModelInterface::ConstPtr model,
                               double dt,
+                              double dz_th,
                               double max_steering_speed = DEFAULT_MAX_STEERING_SPEED,
-                              std::vector<double> hyst_comp = {},
-                              std::vector<double> dz_th = {0.001, 0.001}
+                              std::vector<double> hyst_comp = {}
                              );
         
         void setOutwardNormal(const Eigen::Vector3d& n);

--- a/src/tasks/velocity/CentauroAnkleSteering.cpp
+++ b/src/tasks/velocity/CentauroAnkleSteering.cpp
@@ -5,7 +5,7 @@ using namespace OpenSoT::tasks::velocity;
 SimpleSteering::SimpleSteering(XBot::ModelInterface::ConstPtr model, 
                                std::string wheel_name,
                                std::vector<double> hyst_comp,
-                               std::vector<double> dz_th):
+                               double dz_th):
     _model(model),
     _wheel_name(wheel_name),
     _comp(HysteresisComparator::MakeHysteresisComparator()),
@@ -137,6 +137,17 @@ double SimpleSteering::getDofIndex() const
 
 namespace 
 {
+    Eigen::Vector3d dead_zone_norm(Eigen::Vector3d v, double th)
+    {
+        Eigen::Vector2d v_xy = Eigen::Vector2d(v(0), v(1));
+        if(v_xy.norm() > th)
+        {
+            return Eigen::Vector3d((v_xy - v_xy.normalized()*th)(0), (v_xy - v_xy.normalized()*th)(1), 0);
+        }
+
+        return Eigen::Vector3d::Zero();
+
+    }
     double dead_zone(double x, double th)
     {
         if(x > th)
@@ -185,8 +196,10 @@ double SimpleSteering::computeSteeringAngle(const Eigen::Vector3d& wheel_vel)
     /* Apply deadzone to wheel velocity */
     Eigen::Vector3d vdes_th = _local_R_world * wheel_vel;
     
-    vdes_th.x() = dead_zone(vdes_th.x(), _dz_th[0]);
-    vdes_th.y() = dead_zone(vdes_th.y(), _dz_th[1]);
+//    vdes_th.x() = dead_zone(vdes_th.x(), _dz_th[0]);
+//    vdes_th.y() = dead_zone(vdes_th.y(), _dz_th[1]);
+
+    vdes_th = dead_zone_norm(vdes_th, _dz_th);
 
 //    std::cout << _wheel_name << ", normal  dir =  " << _local_R_world.row(2) << std::endl;
 //    std::cout << _wheel_name << ", forward dir =  " << wheel_forward.transpose() << std::endl;
@@ -299,9 +312,9 @@ namespace
 CentauroAnkleSteering::CentauroAnkleSteering(std::string wheel_name,
                                              XBot::ModelInterface::ConstPtr model, 
                                              double dt,
+                                             double dz_th,
                                              double max_steering_speed,
-                                             std::vector<double> hyst_comp,
-                                             std::vector<double> dz_th):
+                                             std::vector<double> hyst_comp):
     Task("centauro_steering_" + wheel_name, model->getJointNum()),
     _steering(model, wheel_name, hyst_comp, dz_th),
     _max_steering_dq(max_steering_speed*dt),


### PR DESCRIPTION
- Improvement: deadzone filter seems to work better comparing the magnitude of the velocity vector w.r.t. the deadzone threshold. Threshold can be read by the yaml file with default values (0.01m/s)
- Added static function to construct the HysteresisComparator useful to construct the class object with default values from centauro_cartesio