### PR TITLE
Possible fix for cmake error when compiling hcod frontend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -183,9 +183,6 @@ if(${OPENSOT_SOTH_FRONT_END})
     message("Adding src/solvers/HCOD.cpp to compilation")
     set(OPENSOT_SOLVERS_SOURCES ${OPENSOT_SOLVERS_SOURCES} src/solvers/HCOD.cpp)
     set(PRIVATE_TLL hcod_wrapper soth)
-    target_compile_definitions(OpenSoT
-        PUBLIC
-        -DOPENSOT_HAS_SOTH_FRONT_END)
 endif()
 
 
@@ -250,6 +247,12 @@ TARGET_LINK_LIBRARIES(OpenSoT
     matlogger2::matlogger2
     PRIVATE
     ${PRIVATE_TLL})
+    
+if(${OPENSOT_SOTH_FRONT_END})
+	target_compile_definitions(OpenSoT
+        	PUBLIC
+        	-DOPENSOT_HAS_SOTH_FRONT_END)
+endif()
 
 
 ########################################################################


### PR DESCRIPTION
When compiling hcod frontend I was getting an error due to the fact that the `OpenSoT` target is not compiled in this project. I moved the part in the cmake after the `target_link_library` but I am not sure if it is still considering the option.